### PR TITLE
Turn off ssl verify for EA

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A plugin to handle Secrets via Terminus.
 
-NOTE: This is still a WORK IN PROGRESS, this plugin is NOT FUNCTIONAL yet.
+NOTE: This is still a WORK IN PROGRESS; it is not guaranteed to be error-free.
 
 ## Configuration
 

--- a/src/SecretsApi/SecretsApi.php
+++ b/src/SecretsApi/SecretsApi.php
@@ -72,6 +72,7 @@ class SecretsApi
                 'Authorization' => $this->request()->session()->get('session'),
             ],
             'debug' => $debug,
+            'verify' => false, // @todo Remove post-EA, once service is using trusted cert
         ];
         $result = $this->request()->request($url, $options);
         $data = $result->getData();
@@ -146,6 +147,7 @@ class SecretsApi
             'json' => $body,
             'method' => 'POST',
             'debug' => $debug,
+            'verify' => false, // @todo Remove post-EA, once service is using trusted cert
         ];
         $result = $this->request()->request($url, $options);
         return !$result->isError();
@@ -188,6 +190,7 @@ class SecretsApi
             ],
             'method' => 'DELETE',
             'debug' => $debug,
+            'verify' => false, // @todo Remove post-EA, once service is using trusted cert
         ];
         $result = $this->request()->request($url, $options);
         return !$result->isError();


### PR DESCRIPTION
This is needed until we have a cert signed by a trusted CA on the service. We don't want to require customers to use a Pantheon-CA-signed cert.