### PR TITLE
CMS-1030: Scopes syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ terminus secret:set <site> file.json "{}" --type=file
 ```
 
 ```
-terminus secret:set <site> foo bar --scope=ic --scope=user
+terminus secret:set <site> foo bar --scope=ic,user
 
 [notice] Success
 
@@ -140,7 +140,7 @@ The Github token needs all of the "repo" permissions:
 
 Once you have the token, you can set the secret value to the token like this:
 
-`terminus secret:set ${SITE_NAME} github-oauth.github.com ${GITHUB_TOKEN} --type=composer --scope user --scope ic`
+`terminus secret:set ${SITE_NAME} github-oauth.github.com ${GITHUB_TOKEN} --type=composer --scope user,ic`
 
 `github-oauth.github.com` is a magic tokenname for composer that authenticates all github url's with the credentials from the token you provide. There are several ["magic" variable names](https://getcomposer.org/doc/articles/authentication-for-private-packages.md#command-line-global-credential-editing), or you can choose "basic authentication" by providing a COMPOSER_AUTH variable.
 
@@ -173,5 +173,5 @@ read -e COMPOSER_AUTH_JSON <<< {
 }
 EOF
 
-`terminus secret:set ${SITE_NAME} COMPOSER_AUTH ${COMPOSER_AUTH_JSON} --type=env --scope user --scope ic`
+`terminus secret:set ${SITE_NAME} COMPOSER_AUTH ${COMPOSER_AUTH_JSON} --type=env --scope user,ic`
 ```

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The Github token needs all of the "repo" permissions:
 
 Once you have the token, you can set the secret value to the token like this:
 
-`terminus secret:set ${SITE_NAME} github-oauth.github.com ${GITHUB_TOKEN} --type=composer --scope user,ic`
+`terminus secret:set ${SITE_NAME} github-oauth.github.com ${GITHUB_TOKEN} --type=composer --scope=user,ic`
 
 `github-oauth.github.com` is a magic tokenname for composer that authenticates all github url's with the credentials from the token you provide. There are several ["magic" variable names](https://getcomposer.org/doc/articles/authentication-for-private-packages.md#command-line-global-credential-editing), or you can choose "basic authentication" by providing a COMPOSER_AUTH variable.
 

--- a/README.md
+++ b/README.md
@@ -173,5 +173,5 @@ read -e COMPOSER_AUTH_JSON <<< {
 }
 EOF
 
-`terminus secret:set ${SITE_NAME} COMPOSER_AUTH ${COMPOSER_AUTH_JSON} --type=env --scope user,ic`
+`terminus secret:set ${SITE_NAME} COMPOSER_AUTH ${COMPOSER_AUTH_JSON} --type=env --scope=user,ic`
 ```

--- a/src/Commands/SetCommand.php
+++ b/src/Commands/SetCommand.php
@@ -26,6 +26,7 @@ class SetCommand extends SecretBaseCommand implements SiteAwareInterface
      *
      * @option string $type Secret type
      * @option array $scope Secret scope. Available options are ic (integrated composer), user, web, and ops.
+     *   Multiple options should be specified in comma separated format. Ex: --scope=ic,ops,web.
      * @option boolean $debug Run command in debug mode
      *
      * @param string $site_id The name or UUID of a site to retrieve information on
@@ -41,7 +42,7 @@ class SetCommand extends SecretBaseCommand implements SiteAwareInterface
      */
     public function setSecret($site_id, string $name, string $value, array $options = [
         'type' => 'env',
-        'scope' => ['ic'],
+        'scope' => 'ic',
         'debug' => false,
     ])
     {

--- a/src/SecretsApi/SecretsApi.php
+++ b/src/SecretsApi/SecretsApi.php
@@ -102,7 +102,7 @@ class SecretsApi
      *   Secret value.
      * @param string $type
      *   Secret type.
-     * @param array $scopes
+     * @param string $scopes
      *   Secret scopes.
      * @param bool $debug
      *   Whether to return the secrets in debug mode.
@@ -118,7 +118,7 @@ class SecretsApi
         string $name,
         string $value,
         string $type = '',
-        array $scopes = ['ic'],
+        string $scopes = 'ic',
         bool $debug = false
     ): bool {
         if (getenv('TERMINUS_PLUGIN_TESTING_MODE')) {
@@ -140,6 +140,7 @@ class SecretsApi
             $body['type'] = $type;
         }
         if ($scopes) {
+            $scopes = array_map('trim', explode(',', $scopes));
             $body['scopes'] = $scopes;
         }
         $options = [


### PR DESCRIPTION
Updates the `--scope=` option to use standard comma separated syntax instead of requiring repeated declarations of `--scope` for each individual scope. 