### PR TITLE
[CMSO-1277] Allow user to optionally show env and org values in secrets:site:list

### DIFF
--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -33,8 +33,8 @@ class ListCommand extends SecretBaseCommand implements SiteAwareInterface
      *   type: Secret type
      *   value: Secret value
      *   scopes: Secret scopes
-     *   env-overrides: Environment overrides
-     *   org-defaults: Org defaults
+     *   env-values: Environment override values
+     *   org-values: Org default values
      * @default-table-fields name,type,value,scopes
      *
      * @option boolean $debug Run command in debug mode
@@ -86,11 +86,11 @@ class ListCommand extends SecretBaseCommand implements SiteAwareInterface
         $result = [];
 
         foreach ($secrets as $key => $data) {
-            if (array_key_exists($env_name, $data['env-overrides'] ?? [])) {
+            if (array_key_exists($env_name, $data['EnvValues'] ?? [])) {
                 $result[$key] = [
                     'name' => $key,
                     'type' => $data['type'],
-                    'value' => $data['env-overrides'][$env_name],
+                    'value' => $data['env-values'][$env_name],
                     'scopes' => $data['scopes'],
                 ];
             }
@@ -124,7 +124,7 @@ class ListCommand extends SecretBaseCommand implements SiteAwareInterface
                 if ($key == 'scopes') {
                     return implode(', ', $cellData);
                 }
-                if (($key == 'env-overrides') || ($key == 'org-defaults')) {
+                if (($key == 'env-values') || ($key == 'org-values')) {
                     $rows = [];
                     foreach ($cellData as $k => $v) {
                         if ($v) {

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -86,7 +86,7 @@ class ListCommand extends SecretBaseCommand implements SiteAwareInterface
         $result = [];
 
         foreach ($secrets as $key => $data) {
-            if (array_key_exists($env_name, $data['EnvValues'] ?? [])) {
+            if (array_key_exists($env_name, $data['env-values'] ?? [])) {
                 $result[$key] = [
                     'name' => $key,
                     'type' => $data['type'],

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -36,7 +36,6 @@ class ListCommand extends SecretBaseCommand implements SiteAwareInterface
      *   env-overrides: Environment overrides
      *   org-defaults: Org defaults
      * @default-table-fields name,type,value,scopes
-     * @default-fields name,type,value,scopes,env-overrides,org-defaults
      *
      * @option boolean $debug Run command in debug mode
      *

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -33,6 +33,9 @@ class ListCommand extends SecretBaseCommand implements SiteAwareInterface
      *   type: Secret type
      *   value: Secret value
      *   scopes: Secret scopes
+     *   env-overrides: Environment overrides
+     *   org-defaults: Org defaults
+     * @default-fields name,type,value,scopes
      *
      * @option boolean $debug Run command in debug mode
      *
@@ -80,6 +83,21 @@ class ListCommand extends SecretBaseCommand implements SiteAwareInterface
             function ($key, $cellData) {
                 if ($key == 'value' && !$cellData) {
                     return '[REDACTED]';
+                }
+                if ($key == 'scopes') {
+                    return implode(', ', $cellData);
+                }
+                if (($key == 'env-overrides') || ($key == 'org-defaults')) {
+                    $rows = [];
+                    foreach ($cellData as $k => $v) {
+                        if ($v) {
+                            $rows[] = "$k=$v";
+                        }
+                        else {
+                            $rows[] = "$k";
+                        }
+                    }
+                    return implode(', ', $rows);
                 }
                 return $cellData;
             }

--- a/src/SecretsApi/SecretsApi.php
+++ b/src/SecretsApi/SecretsApi.php
@@ -67,7 +67,7 @@ class SecretsApi
             }
             return array_values($this->secrets);
         }
-        $url = sprintf('%s/sites/%s/secrets', $this->getBaseURI(), $site_id);
+        $url = sprintf('%s/sites/%s/secrets/showall', $this->getBaseURI(), $site_id);
         $options = [
             'headers' => [
                 'Accept' => 'application/json',
@@ -85,18 +85,8 @@ class SecretsApi
                 'type' => $secretValue->Type,
                 'value' => $secretValue->Value ?? null,
                 'scopes' => $secretValue->Scopes,
-            ];
-
-            // SIMULATION. Put in some fake data for env and org values.
-            // Redact the env and org data if the site data was redacted.
-            $secrets[$secretKey]["env-overrides"] = [
-                'dev' => $secretValue->Value ? $secretValue->Value . '-for-dev' : null,
-                'live' => $secretValue->Value ? $secretValue->Value . '-for-live' : null,
-            ];
-            $secrets[$secretKey]["org-defaults"] = [
-                'default' => $secretValue->Value ? $secretValue->Value . '-from-org' : null,
-                'dev' => $secretValue->Value ? $secretValue->Value . '-org-for-dev' : null,
-                'live' => $secretValue->Value ? $secretValue->Value . '-org-for-live' : null,
+                'env-values' => $secretValue->EnvValues ?? [],
+                'org-values' => $secretValue->OrgValues ?? [],
             ];
         }
         return $secrets;

--- a/src/SecretsApi/SecretsApi.php
+++ b/src/SecretsApi/SecretsApi.php
@@ -85,8 +85,8 @@ class SecretsApi
                 'type' => $secretValue->Type,
                 'value' => $secretValue->Value ?? null,
                 'scopes' => $secretValue->Scopes,
-                'env-values' => $secretValue->EnvValues ?? [],
-                'org-values' => $secretValue->OrgValues ?? [],
+                'env-values' => (array) ($secretValue->EnvValues ?? []),
+                'org-values' => (array) ($secretValue->OrgValues ?? []),
             ];
         }
         return $secrets;

--- a/src/SecretsApi/SecretsApi.php
+++ b/src/SecretsApi/SecretsApi.php
@@ -79,11 +79,24 @@ class SecretsApi
         $data = $result->getData();
         $secrets = [];
         foreach ($data->Secrets ?? [] as $secretKey => $secretValue) {
-            $secrets[] = [
+            // Key the rows of fields entries by their secret keys
+            $secrets[$secretKey] = [
                 'name' => $secretKey,
                 'type' => $secretValue->Type,
                 'value' => $secretValue->Value ?? null,
-                'scopes' => implode(', ', $secretValue->Scopes),
+                'scopes' => $secretValue->Scopes,
+            ];
+
+            // SIMULATION. Put in some fake data for env and org values.
+            // Redact the env and org data if the site data was redacted.
+            $secrets[$secretKey]["env-overrides"] = [
+                'dev' => $secretValue->Value ? $secretValue->Value . '-for-dev' : null,
+                'live' => $secretValue->Value ? $secretValue->Value . '-for-live' : null,
+            ];
+            $secrets[$secretKey]["org-defaults"] = [
+                'default' => $secretValue->Value ? $secretValue->Value . '-from-org' : null,
+                'dev' => $secretValue->Value ? $secretValue->Value . '-org-for-dev' : null,
+                'live' => $secretValue->Value ? $secretValue->Value . '-org-for-live' : null,
             ];
         }
         return $secrets;


### PR DESCRIPTION
This PR shows how to add optional env-override and org-override fields. Having different default fields for human-readable and machine-readable format types is supposed to be possible, but currently broken, so this PR does not demonstrate that.

![Screen Shot 2023-02-22 at 11 27 02 AM](https://user-images.githubusercontent.com/612191/220744252-55b5763e-95db-49c7-ac5d-add50bd45c0f.png)
