### PR TITLE
[BUGS-6926] Rewrite update error message before printing it, and set CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners. See:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @pantheon-systems/cms-ecosystem

--- a/src/SecretsApi/SecretsApi.php
+++ b/src/SecretsApi/SecretsApi.php
@@ -220,7 +220,7 @@ class SecretsApi
                 $result = $this->request()->request($url, $options);
             }
             else {
-                $result->setData(sprintf("Secret '%s' already exists. To update it, omit type and scopes options.", $name));
+                $result->setData(sprintf("Secret '%s' already exists. To update the value, omit type and scopes options.", $name));
             }
         }
         return $result;

--- a/src/SecretsApi/SecretsApi.php
+++ b/src/SecretsApi/SecretsApi.php
@@ -219,6 +219,9 @@ class SecretsApi
                 unset($options['json']['name']);
                 $result = $this->request()->request($url, $options);
             }
+            else {
+                $result->setData(sprintf("Secret '%s' already exists. To update it, omit type and scopes options.", $name));
+            }
         }
         return $result;
     }


### PR DESCRIPTION
Before:

```
 [error]  An error happened when trying to set the secret.
 [error]  Secret 'foo' already exists. Use PATCH if you want to update it.
```

After:

```
[error]  An error happened when trying to set the secret.
[error]  Secret 'foo' already exists. To update it, omit type and scopes options.
```