### PR TITLE
Fallback to use same papi host as terminus host if sandbox.

### DIFF
--- a/src/SecretsApi/SecretsApi.php
+++ b/src/SecretsApi/SecretsApi.php
@@ -32,6 +32,9 @@ class SecretsApi
         if (!$host && strpos($config->get('host'), 'hermes.sandbox-') !== false) {
             $host = str_replace('hermes', 'pantheonapi', $config->get('host'));
         }
+        if (!$host && strpos($config->get('host'), 'sandbox-') !== false) {
+            $host = $config->get('host');
+        }
         // If host is still not set, use the default host.
         if (!$host) {
             $host = 'api.pantheon.io';


### PR DESCRIPTION
Since internal API change, this is not getting the right host for secrets API. This PR should fix it.