### PR TITLE
Show environment-specific secrets in list

### DIFF
--- a/src/Commands/SiteListCommand.php
+++ b/src/Commands/SiteListCommand.php
@@ -72,6 +72,9 @@ class SiteListCommand extends SecretBaseCommand implements SiteAwareInterface
         // filter down to just the secret values there.
         if (!empty($env_name)) {
             $secrets = $this->secretsForEnv($result, $env_name);
+            if(!empty($secrets)) {
+                $result = array_replace($result, $secrets);
+            }
             $print_options = [
                 'message' => "There are no environment overrides in the environment '$env_name'.",
             ];


### PR DESCRIPTION
This PR ensures that the `secret:site:list` command shows the correct value for secrets that have been overridden on a per-environment basis.