### PR TITLE
getSite() is now replaced by getSiteById().

### DIFF
--- a/src/Commands/SiteDeleteCommand.php
+++ b/src/Commands/SiteDeleteCommand.php
@@ -48,7 +48,7 @@ class SiteDeleteCommand extends SecretBaseCommand implements SiteAwareInterface
             $env_name = null;
         }
 
-        $site = $this->getSite($site_id);
+        $site = $this->getSiteById($site_id);
         $this->setupRequest();
         $result = $this->secretsApi->deleteSecret($site->id, $name, $env_name, $options['debug']);
         if ($result->isError()) {

--- a/src/Commands/SiteListCommand.php
+++ b/src/Commands/SiteListCommand.php
@@ -59,7 +59,7 @@ class SiteListCommand extends SecretBaseCommand implements SiteAwareInterface
         if (strpos($site_id, '.') !== false) {
             list($site_id, $env_name) = explode('.', $site_id, 2);
         }
-        $site = $this->getSite($site_id);
+        $site = $this->getSiteById($site_id);
         $this->setupRequest();
         $result = $this->secretsApi->listSecrets($site->id, $options['debug']);
         if ($result instanceof RequestOperationResult) {

--- a/src/Commands/SiteLocalGenerateCommand.php
+++ b/src/Commands/SiteLocalGenerateCommand.php
@@ -49,7 +49,7 @@ class SiteLocalGenerateCommand extends SecretBaseCommand implements SiteAwareInt
         if (strpos($site_id, '.') !== false) {
             list($site_id, $env_name) = explode('.', $site_id, 2);
         }
-        $site = $this->getSite($site_id);
+        $site = $this->getSiteById($site_id);
         $this->setupRequest();
         $result = $this->secretsApi->fetchSecrets($site->id);
         if ($result->getStatusCode() != 200) {

--- a/src/Commands/SiteSetCommand.php
+++ b/src/Commands/SiteSetCommand.php
@@ -56,7 +56,7 @@ class SiteSetCommand extends SecretBaseCommand implements SiteAwareInterface
             $env_name = null;
         }
 
-        $site = $this->getSite($site_id);
+        $site = $this->getSiteById($site_id);
         $env_to_check = $env_name ?? 'dev';
         $env = $site->getEnvironments()->get($env_to_check);
         $php_version = $env->getPHPVersion();


### PR DESCRIPTION
Needed for compatibility with Terminus 4.