### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,10 @@ Note: You can add an environment override only to existing secrets; otherwise, i
 
 The secrets `list` command provides a list of all secrets available for a site. The following fields are available:
 
-- `Name`
-- `Scope`
-- `Type`
-- `Value`
+- `Secret name`
+- `Secret scopes`
+- `Secret type`
+- `Secret value`
 - `Environment override values`
 - `Org values`
 
@@ -372,10 +372,10 @@ Note: You can add an environment override only to existing secrets; otherwise, i
 
 The secrets `list` command provides a list of all secrets available for an organization. The following fields are available:
 
-- `Name`
-- `Scope`
-- `Type`
-- `Value`
+- `Secret name`
+- `Secret scopes`
+- `Secret type`
+- `Secret value`
 - `Environment override values`
 
 Note that the `value` field will contain a placeholder value unless the `user` scope was specified when the secret was set.


### PR DESCRIPTION
👋 Hey folks.

This change updates the README file to alter the way we list Field Names in our documentation. Currently, field names within the README are shown as having "Title Casing" (ie: every word is capitalized), however, in practice our field names are actually stored in "Sentence Casing" (only the first word is capitalized).

The reason behind this is that users cannot just copy the field names from our docs and run them verbatim, because they'll break due to capitalization differences. This can be seen here:
![Screenshot 2025-06-24 at 1 51 01 PM](https://github.com/user-attachments/assets/43eb89d9-12f1-4336-abbf-e0eee55e1b69)

By having our listed field names match the actual stored values, users can copy/paste field names from docs directly into commands without getting a "field {name}, is not defined" error.  Other fields, such as `Scope` are actually stored as a plural in the field name, so our documentation says the field name is "Scope", but in reality it's plural: `Secret scopes`. 
